### PR TITLE
Fix broken weeb exclusive feature.

### DIFF
--- a/salmon/tagger/sources/deezer.py
+++ b/salmon/tagger/sources/deezer.py
@@ -62,8 +62,8 @@ class Scraper(DeezerBase, MetadataMixin):
                 stream_id=track["SNG_ID"],
                 md5_origin=track.get("MD5_ORIGIN"),
                 media_version=track.get("MEDIA_VERSION"),
-                lossless=bool(int(track.get("FILESIZE_FLAC"))),
-                mp3_320=bool(int(track.get("FILESIZE_MP3_320"))),
+                lossless=True,
+                mp3_320=True,
             )
         return dict(tracks)
 


### PR DESCRIPTION
So Deezer decided to filesizes to 0, effectively breaking weeb exclusive features.
This is a very hacky and temporary fix.