### PR TITLE
Move dir to config.DOWNLOAD_DIRECTORY if specified

### DIFF
--- a/salmon/uploader/__init__.py
+++ b/salmon/uploader/__init__.py
@@ -199,6 +199,11 @@ def upload(
         fg="green",
         bold=True,
     )
+    
+    if config.DOWNLOAD_DIRECTORY:
+        dest = config.DOWNLOAD_DIRECTORY
+        shutil.move(path, dest)
+        return click.secho(f"\nMoved folder to download directory", fg="yellow")
 
     if config.COPY_UPLOADED_URL_TO_CLIPBOARD:
         pyperclip.copy(url)


### PR DESCRIPTION
If DOWNLOAD_DIRECTORY is specified in smoked-salmon/config.py, move the folder to the download dir. This is useful for when torrent clients are watching the DOTTORRENTS_DIR.