### PR TITLE
bugfix: beatport has stopped using their 'pro' subdomain, using just …

### DIFF
--- a/salmon/sources/beatport.py
+++ b/salmon/sources/beatport.py
@@ -5,9 +5,9 @@ from salmon.sources.base import BaseScraper
 
 class BeatportBase(BaseScraper):
 
-    url = site_url = "https://pro.beatport.com"
-    search_url = "https://pro.beatport.com/search/releases"
+    url = site_url = "https://beatport.com"
+    search_url = "https://beatport.com/search/releases"
     release_format = "/release/{rls_name}/{rls_id}"
     regex = re.compile(
-        r"^https?://(?:(?:www|pro|classic)\.)?beatport\.com/release/.+?/(\d+)/?$"
+        r"^https?://(?:(?:www|classic)\.)?beatport\.com/release/.+?/(\d+)/?$"
     )


### PR DESCRIPTION
…beatport.com instead to fix bug where salmon was unable to fetch metadata from beatport