### PR TITLE
This is a meta commit with all the changes from xmomorf + elghoto

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.*
+Dockerfile

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -12,6 +12,7 @@ on:
   push:
     branches:
       - master
+      - elghoto-version
 
 jobs:
   build_and_push_docker:

--- a/.github/workflows/docker_release.yml
+++ b/.github/workflows/docker_release.yml
@@ -1,0 +1,62 @@
+name: Docker Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      docker_tags:
+        type: string
+        description: "Docker Tags"
+        required: true
+        default: "dev"
+
+  push:
+    branches:
+      - master
+
+jobs:
+  build_and_push_docker:
+    runs-on: ubuntu-latest
+    env:
+      release_arch: "linux/amd64,linux/arm64"
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=latest,enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=raw,value={{date 'YYYY-MM-DD'}},enable=${{ github.event_name != 'workflow_dispatch' }}
+            type=raw,value=${{ inputs.docker_tags }},enable=${{ github.event_name == 'workflow_dispatch' }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and Push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ env.release_arch }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ accounts.json
 salmon/web/static/specs
 !.gitkeep
 plugins/
+.python-version
+.venv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,47 @@
+# Dockerfile created by Bendall and @kieraneglin
+# 
+# Step by step:
+#
+# 1. Create docker image:
+# $ docker image build -t salmon .
+#   - You can pass in `uid` and `gid` as `--build-arg`s if you need to change the user and group IDs.
+#
+# 2. Alias docker command and replace /path/to with your desired path. (Add to .bashrc or whatever):
+# alias salmon='docker run --rm -it -v /path/to/config.py:/salmon/config.py -v /path/to/accounts.json:/salmon/accounts.json -v /path/to/downloads:/downloads -v /path/to/queue:/queue -v /path/to/torrents:/torrents -p 55110:55110/tcp salmon'
+#
+# Done
+
+FROM python:3.11-slim-buster
+
+ARG uid=1000
+ARG gid=1000
+
+WORKDIR /salmon
+
+COPY ./ /salmon
+
+RUN apt-get update \
+    && echo "----- Installing dependencies" \
+    && apt-get install -y gcc sox flac mp3val \
+    && echo "----- Installing python requirements" \
+    && pip install --trusted-host pypi.python.org -r requirements.txt \
+    && echo "----- Initializing salmon" \
+    # If `WEB_HOST` exists in config.py.txt, leave it alone. Otherwise append `WEB_HOST = '0.0.0.0'`
+    && grep -q "WEB_HOST" config.py.txt || echo "\nWEB_HOST = '0.0.0.0'" >> config.py.txt \
+    && cp config.py.txt config.py \
+    && python run.py migrate \
+    && echo "----- Adding salmon user and group and chown" \
+    && groupadd -r salmon -g ${gid} \
+    && useradd --no-log-init -MNr -g ${gid} -u ${uid} salmon \
+    && chown salmon:salmon -R /salmon \
+    && apt-get remove -y gcc \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+USER salmon:salmon
+
+EXPOSE 55110
+
+VOLUME ["/downloads", "/torrents", "/queue"]
+
+ENTRYPOINT ["python", "run.py"]

--- a/config.py.txt
+++ b/config.py.txt
@@ -17,4 +17,14 @@ DEFAULT_TRACKER = 'RED'
 RED_SESSION = 'get-from-site-cookie' #Required for now. (waiting on reports api support)
 OPS_SESSION = 'get-from-site-cookie'
 RED_API_KEY = 'red-api-key' #Needs uploading privileges. Optional for now. Some things still use session.
+OPS_API_KEY = 'ops-api-key' #Needs uploading privileges. Optional for now. Some things still use session.
 TRACKER_LIST=['RED','OPS'] #Remove one of these if you don't want multi-tracker support.
+
+#RUTORRENT UPLOAD, works with xmlrpc
+OPS_LABEL = 'ops'
+RED_LABEL = 'red'
+OPS_DIR = '/downloads/complete/orpheus'
+RED_DIR = '/downloads/complete/redacted'
+TRACKER_DIRS = {'OPS': OPS_DIR, 'RED': RED_DIR}
+TRACKER_LABELS = {'OPS': OPS_LABEL, 'RED': RED_LABEL}
+RUTORRENT_URL = "http://RUTORRENT_ADDRESS:9380/plugins/rpc/rpc.php"

--- a/requirements.txt
+++ b/requirements.txt
@@ -798,3 +798,5 @@ yarl==1.9.4 ; python_version >= "3.9" and python_version < "4.0" \
 yaspin==3.0.1 ; python_version >= "3.9" and python_version < "4.0" \
     --hash=sha256:9c04aa69cce9be83e1ea3134a6712e749e6c0c9cd02599023713e6befd7bf369 \
     --hash=sha256:c4b5d2ca23ae664b87a5cd53401c5107cef12668a71d9ee5ea5536045f364121
+Unidecode==1.3.8 ; python_version >= "3.5" \
+    --hash=sha256:d130a61ce6696f8148a3bd8fe779c99adeb4b870584eeb9526584e9aa091fd39

--- a/run.py
+++ b/run.py
@@ -12,8 +12,8 @@ if __name__ == '__main__':
     try:
         commandgroup(obj={})
     except (UploadError, FilterError) as e:
-        click.secho(str(e), fg='red', bold=True)
+        click.secho(f"There was an error: {e}", fg="red", bold=True)
     except LoginError:
         click.secho(f'Failed to log in. Is your session cookie up to date?', fg='red')
     except ImportError as e:
-        click.secho(f'You are missing required dependencies: {e}', fg='red')
+        click.secho(f"You are missing required dependencies: {e}", fg="red")

--- a/salmon/__init__.py
+++ b/salmon/__init__.py
@@ -38,7 +38,7 @@ DEFAULT_VALUES = {
     "NATIVE_SPECTRALS_VIEWER": False,
     "PROMPT_PUDDLETAG": False,
     "ADD_EDITION_TITLE_TO_ALBUM_TAG": True,
-    "WEB_HOST": "http://127.0.0.1:55110",
+    "WEB_HOST": "127.0.0.1",
     "WEB_PORT": 55110,
     "WEB_STATIC_ROOT_URL": "/static",
     "COMPRESS_SPECTRALS": False,
@@ -57,6 +57,7 @@ DEFAULT_VALUES = {
     "RED_DOTTORRENTS_DIR": False,
     "OPS_DOTTORRENTS_DIR": False,
     "TRACKER_LIST": [],
+    "YES_ALL": False,
 }
 
 

--- a/salmon/checks/integrity.py
+++ b/salmon/checks/integrity.py
@@ -1,5 +1,6 @@
 import re
 import subprocess
+import os
 
 import click
 
@@ -18,28 +19,73 @@ def check_integrity(path):
         return _check_flac_integrity(path)
     elif path.lower().endswith(".mp3"):
         return _check_mp3_integrity(path)
+    elif os.path.isdir(path):
+        integrities_out = []
+        integrities = True
+        for root, _, figles in os.walk(path):
+            for f in figles:
+                if any(f.lower().endswith(ext) for ext in [".mp3", ".flac"]):
+                    filepath = os.path.join(root, f)
+                    (integrity, integrity_out) = check_integrity(filepath)
+                    integrities = integrities and integrity
+                    integrities_out.append(integrity_out)
+        return(integrities, "\n".join(integrities_out))
     raise click.Abort
 
 
 def format_integrity(arg):
-    return arg
+    return arg[1]
 
 
 def _check_flac_integrity(path):
-    resp = subprocess.check_output(["flac", "-wt", path], stderr=subprocess.STDOUT)
-    important_lines = []
-    for line in resp.decode("utf-8").split("\n"):
-        for important_line_re in FLAC_IMPORTANT_REGEXES:
-            if important_line_re.match(line):
-                important_lines.append(line)
-    return "\n".join(important_lines)
+    try:
+        resp = subprocess.check_output(["flac", "-wt", path], stderr=subprocess.STDOUT)
+        important_lines = []
+        for line in resp.decode("utf-8").split("\n"):
+            for important_line_re in FLAC_IMPORTANT_REGEXES:
+                if important_line_re.match(line):
+                    important_lines.append(line)
+        return (True, "\n".join(important_lines))
+    except:
+        return (False, "Failed integrity")
 
 
 def _check_mp3_integrity(path):
-    resp = subprocess.check_output(["mp3val", path])
-    important_lines = []
-    for line in resp.decode("utf-8").split("\n"):
-        for important_line_re in MP3_IMPORTANT_REGEXES:
-            if important_line_re.match(line):
-                important_lines.append(line)
-    return "\n".join(important_lines)
+    try:
+	    resp = subprocess.check_output(["mp3val", path])
+	    important_lines = []
+	    for line in resp.decode("utf-8").split("\n"):
+	        for important_line_re in MP3_IMPORTANT_REGEXES:
+	            if important_line_re.match(line):
+	                important_lines.append(line)
+	    return (True, "\n".join(important_lines))
+    except:
+        return (False, "Failed integrity")
+
+def sanitize_integrity(path):
+    if path.lower().endswith(".flac"):
+        return _sanitize_flac(path)
+    elif path.lower().endswith(".mp3"):
+        return _sanitize_mp3(path)
+    elif os.path.isdir(path):
+        integrities_out = []
+        integrities = True
+        for root, _, figles in os.walk(path):
+            for f in figles:
+                if any(f.lower().endswith(ext) for ext in [".mp3", ".flac"]):
+                    filepath = os.path.join(root, f)
+                    integrity = sanitize_integrity(filepath)
+                    integrities = integrities and integrity
+        return integrities
+    raise click.Abort
+
+def _sanitize_flac(path):
+    os.rename(path, path + ".corrupted")
+    subprocess.run(["flac", path + ".corrupted", "-o", path])
+    os.remove(path + ".corrupted")
+    subprocess.run(["metaflac", "--dont-use-padding", "--remove", "--block-type=PADDING,PICTURE", path])
+    subprocess.run(["metaflac", "--add-padding=8192", path])
+    return True
+
+def _sanitize_mp3(path):
+    return True

--- a/salmon/commands.py
+++ b/salmon/commands.py
@@ -1,7 +1,7 @@
 import asyncio
+import html
 import importlib
 import os
-import html
 from urllib import parse
 
 import click

--- a/salmon/common/__init__.py
+++ b/salmon/common/__init__.py
@@ -7,10 +7,10 @@ from requests import RequestException
 from salmon.common.aliases import AliasedCommands  # noqa: F401
 from salmon.common.constants import RE_FEAT  # noqa: F401
 from salmon.common.figles import (  # noqa: F401
+    alac_to_flac,
     compress,
     create_relative_path,
     get_audio_files,
-    alac_to_flac,
 )
 from salmon.common.regexes import (  # noqa: F401
     parse_copyright,
@@ -19,12 +19,12 @@ from salmon.common.regexes import (  # noqa: F401
 )
 from salmon.common.strings import (  # noqa: F401
     fetch_genre,
+    format_size,
     less_uppers,
     make_searchstrs,
     normalize_accents,
     strip_template_keys,
     truncate,
-    format_size,
 )
 from salmon.errors import ScrapeError
 
@@ -61,7 +61,7 @@ prompt_async = Prompt()
 
 def flush_stdin():
     try:
-        from termios import tcflush, TCIOFLUSH
+        from termios import TCIOFLUSH, tcflush
 
         tcflush(sys.stdin, TCIOFLUSH)
     except:  # noqa E722

--- a/salmon/common/constants.py
+++ b/salmon/common/constants.py
@@ -9,6 +9,7 @@ SPLIT_CHARS = (
 )
 
 COPYRIGHT_SEARCHES = (
+    r".* \d{4} (.*)$",
     r"marketed by (.+?) under",
     r"(?:, )?under(?: exclusive)? licen(?:s|c)e to ([^,]+)",
     r"d/b/a (.+)",

--- a/salmon/images/__init__.py
+++ b/salmon/images/__init__.py
@@ -10,7 +10,7 @@ from salmon import config
 from salmon.common import AliasedCommands, commandgroup
 from salmon.database import DB_PATH
 from salmon.errors import ImageUploadFailed
-from salmon.images import imgur, ptpimg, emp, catbox
+from salmon.images import catbox, emp, imgur, ptpimg
 
 loop = asyncio.get_event_loop()
 
@@ -110,13 +110,13 @@ def chunker(seq, size=4):
         yield seq[pos : pos + size]
 
 
-def upload_cover(path):
+def upload_cover(path, scene=False):
     """
     Search a folder for a cover image, and if found, upload it.
     The image url is returned, otherwise None.
     """
     for filename in os.listdir(path):
-        if re.match(r"^(cover|folder)\.(jpe?g|png)$", filename, flags=re.IGNORECASE):
+        if re.match(r"^(cover|folder)\.(jpe?g|png)$", filename, flags=re.IGNORECASE) or (scene and re.match(r"^.*\.(jpe?g|png)$", filename, flags=re.IGNORECASE)):
             click.secho(
                 f"Uploading cover to {config.COVER_UPLOADER}...", fg="yellow", nl=False
             )

--- a/salmon/images/base.py
+++ b/salmon/images/base.py
@@ -6,6 +6,7 @@ from random import choice
 
 import requests
 from bs4 import BeautifulSoup
+
 from salmon.constants import UAGENTS
 from salmon.errors import ImageUploadFailed
 

--- a/salmon/images/catbox.py
+++ b/salmon/images/catbox.py
@@ -1,14 +1,12 @@
-import requests
-
-from salmon import config
-from salmon.errors import ImageUploadFailed
-from salmon.images.base import BaseImageUploader
-
 from random import choice
 
+import requests
 from bs4 import BeautifulSoup
-from salmon.constants import UAGENTS
 
+from salmon import config
+from salmon.constants import UAGENTS
+from salmon.errors import ImageUploadFailed
+from salmon.images.base import BaseImageUploader
 
 HEADERS = {
     "User-Agent": choice(UAGENTS),

--- a/salmon/images/emp.py
+++ b/salmon/images/emp.py
@@ -6,6 +6,7 @@ from random import choice
 
 import requests
 from bs4 import BeautifulSoup
+
 from salmon.constants import UAGENTS
 from salmon.errors import ImageUploadFailed
 from salmon.images.base import BaseImageUploader

--- a/salmon/images/imgur.py
+++ b/salmon/images/imgur.py
@@ -10,6 +10,7 @@ CLIENT = ImgurAPI(
 )
 
 
+
 class ImageUploader:
     def upload_file(self, filename):
         try:

--- a/salmon/images/ptpimg.py
+++ b/salmon/images/ptpimg.py
@@ -4,7 +4,6 @@ from salmon import config
 from salmon.errors import ImageUploadFailed
 from salmon.images.base import BaseImageUploader
 
-
 HEADERS = {"referer": "https://ptpimg.me/index.php", "User-Agent": config.USER_AGENT}
 
 
@@ -23,4 +22,6 @@ class ImageUploader(BaseImageUploader):
                     f"Failed decoding body:\n{e}\n{resp.content}"
                 ) from e
         else:
-            raise ImageUploadFailed(f"Failed. Status {resp.status_code}:\n{resp.content}")
+            raise ImageUploadFailed(
+                f"Failed. Status {resp.status_code}:\n{resp.content}"
+            )

--- a/salmon/rutorrent/rutorrent.py
+++ b/salmon/rutorrent/rutorrent.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+import xmlrpc.client
+
+def add_torrent_to_rutorrent(server_url, torrent_path, directory, label):
+    client = xmlrpc.client.Server(server_url)
+    with open(torrent_path, 'rb') as torrent_file:
+        torrent_bin = xmlrpc.client.Binary(torrent_file.read())
+        client.load.raw_start_verbose('', torrent_bin, 'print=d.hash=', 'd.directory.set=' + directory, 'd.custom1.set=' + label)

--- a/salmon/search/__init__.py
+++ b/salmon/search/__init__.py
@@ -20,7 +20,7 @@ from salmon.search import (
     itunes,
     junodownload,
     musicbrainz,
-    tidal,
+#    tidal,
 )
 
 SEARCHSOURCES = {
@@ -30,7 +30,7 @@ SEARCHSOURCES = {
     "Junodownload": junodownload,
     "Discogs": discogs,
     "Beatport": beatport,
-    "Tidal": tidal,
+#    "Tidal": tidal,
     "Deezer": deezer,
 }
 

--- a/salmon/search/deezer.py
+++ b/salmon/search/deezer.py
@@ -2,9 +2,15 @@ import asyncio
 import re
 from itertools import chain
 
-from salmon.search.base import ArtistRlsData, LabelRlsData, IdentData, SearchMixin
-from salmon.sources import DeezerBase
 from ratelimit import limits, sleep_and_retry
+
+from salmon.search.base import (
+    ArtistRlsData,
+    IdentData,
+    LabelRlsData,
+    SearchMixin,
+)
+from salmon.sources import DeezerBase
 
 
 class Searcher(DeezerBase, SearchMixin):
@@ -70,6 +76,7 @@ class Searcher(DeezerBase, SearchMixin):
         albums = []
         i = 0
         while i < maximum or maximum == 0:
+            print(i)
             i += 25
             for rls in resp["data"]:
                 album = await self.get_json(f"/album/{rls['id']}")

--- a/salmon/search/junodownload.py
+++ b/salmon/search/junodownload.py
@@ -30,7 +30,8 @@ class Searcher(JunodownloadBase, SearchMixin):
                 rls_id = re.search(r"/products/[^/]+/([\d-]+)", su_title["href"])[1]
                 title = su_title.string
 
-                right_blob = meta.find('div', attrs={'class': 'text-sm mb-3 mb-lg-3'})
+                #right_blob = meta.find('div', attrs={'class': 'text-sm mb-3 mb-lg-3'})
+                right_blob = meta.find('div', attrs={'class': 'text-sm text-muted mt-3'})
 
                 right_blob_elements_count = len(
                     right_blob.get_text(separator="|").strip().split("|")
@@ -39,7 +40,7 @@ class Searcher(JunodownloadBase, SearchMixin):
                     # skip item missing one or more of: catno, date or genre
                     continue
 
-                date = right_blob.find('br').next_sibling.strip()
+                date = right_blob.find('br').next.strip()
                 year = int(date[-2:])
 
                 if 40 <= year <= 99:

--- a/salmon/sources/__init__.py
+++ b/salmon/sources/__init__.py
@@ -6,7 +6,7 @@ from salmon.sources.discogs import DiscogsBase
 from salmon.sources.itunes import iTunesBase
 from salmon.sources.junodownload import JunodownloadBase
 from salmon.sources.musicbrainz import MusicBrainzBase
-from salmon.sources.tidal import TidalBase
+#from salmon.sources.tidal import TidalBase
 
 SOURCE_ICONS = {
     "Bandcamp": "https://ptpimg.me/1b382r.png",
@@ -16,5 +16,5 @@ SOURCE_ICONS = {
     "iTunes": "https://ptpimg.me/5d47fv.png",
     "Junodownload": "https://ptpimg.me/2852h1.png",
     "MusicBrainz": "https://ptpimg.me/y87lp2.png",
-    "Tidal": "https://ptpimg.me/dhyvs6.png",
+#    "Tidal": "https://ptpimg.me/dhyvs6.png",
 }

--- a/salmon/sources/base.py
+++ b/salmon/sources/base.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import re
+import traceback
 from collections import namedtuple
 from random import choice
 from string import Formatter
@@ -64,10 +65,12 @@ class BaseScraper:
                 self.url + url, params=params, headers=headers, timeout=7
             )
             if result.status_code != 200:
-                raise ScrapeError(f"Status code {result.status_code}.", result.json())
+                class_hierarchy = ' -> '.join([cls.__name__ for cls in self.__class__.mro()[:-1]])
+                traceback.print_stack()
+                raise ScrapeError(f"{self.__class__.__name__}({class_hierarchy}): Status code {result.status_code}.", result.json())
             return result.json()
         except json.decoder.JSONDecodeError as e:
-            raise ScrapeError("Did not receive JSON from API.") from e
+            raise ScrapeError(f"{self.__class__.__name__}: Did not receive JSON from API.") from e
 
     async def create_soup(self, url, params=None, headers=None, **kwargs):
         """

--- a/salmon/sources/itunes.py
+++ b/salmon/sources/itunes.py
@@ -8,6 +8,6 @@ class iTunesBase(BaseScraper):
     url = site_url = "https://itunes.apple.com"
     search_url = "https://itunes.apple.com/search"
     regex = re.compile(
-        "^https?://itunes\.apple\.com/(?:(\w{2,4})/)?album/(?:[^/]*/)?([^\?]+)"
+        "^https?://(itunes|music)\.apple\.com/(?:(\w{2,4})/)?album/(?:[^/]*/)?([^\?]+)"
     )
     release_format = "/us/album/{rls_id}"

--- a/salmon/sources/tidal.py
+++ b/salmon/sources/tidal.py
@@ -61,4 +61,8 @@ def get_tidal_regions_to_fetch():
                 return [k for k, v in ACCOUNTS["Tidal"].items() if v]
         except ImportError:
             pass
+<<<<<<< HEAD
     raise ScrapeError("No regions defined for Tidal to grab from")
+=======
+    raise ScrapeError(f"No regions defined for Tidal to grab from")
+>>>>>>> bd63238 (This is a meta commit with all the changes from xmomorf + elghoto)

--- a/salmon/tagger/__init__.py
+++ b/salmon/tagger/__init__.py
@@ -72,7 +72,13 @@ def validate_encoding(ctx, param, value):
     is_flag=True,
     help="Whether or not to use the original metadata.",
 )
-def tag(path, source, encoding, overwrite):
+@click.option(
+    "--auto-rename",
+    "-n",
+    is_flag=True,
+    help=f'Rename files and folders automatically',
+)
+def tag(path, source, encoding, overwrite, auto_rename):
     """Interactively tag an album"""
     click.secho(f"\nProcessing {path}", fg="cyan", bold=True)
     standardize_tags(path)
@@ -84,12 +90,12 @@ def tag(path, source, encoding, overwrite):
 
     metadata = get_metadata(path, tags, rls_data)
     metadata = review_metadata(metadata, metadata_validator_base)
-    tag_files(path, tags, metadata)
+    tag_files(path, tags, metadata, auto_rename)
 
     download_cover_if_nonexistent(path, metadata["cover"])
     tags = check_tags(path)
-    path = rename_folder(path, metadata)
-    rename_files(path, tags, metadata)
+    path = rename_folder(path, metadata, auto_rename)
+    rename_files(path, tags, metadata, auto_rename)
     check_folder_structure(path)
     click.secho(f"\nProcessed {path}", fg="cyan", bold=True)
 

--- a/salmon/tagger/__init__.py
+++ b/salmon/tagger/__init__.py
@@ -149,6 +149,8 @@ def metadata_validator_base(metadata):
         len(metadata["label"]) < 2 or len(metadata["label"]) > 80
     ):
         raise InvalidMetadataError("Label must be over 2 and under 80 characters.")
+    if "records dk" in metadata["label"].lower():
+        raise InvalidMetadataError("Records DK is not a label. It's a platform for releasing albums. Please change the label (e.g Self Released)")
     if metadata["catno"] and (
         len(metadata["catno"]) < 2 or len(metadata["catno"]) > 80
     ):

--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -129,8 +129,10 @@ def combine_tracks(base, meta):
             except StopIteration:
                 raise TrackCombineError(f"Disc {disc} track {num} does not exist.")
 
-            if re_strip(track["title"]) != re_strip(btrack["title"]):
+            if re_strip(track["title"]) != re_strip(btrack["title"]) and btrack["title"] is not None:
                 continue
+            if btrack["title"] is None:
+                btrack["title"] = track["title"]
             base_artists = {(re_strip(a[0]), a[1]) for a in btrack["artists"]}
             btrack["artists"] = list(btrack["artists"])
             for a in track["artists"]:

--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -1,5 +1,6 @@
 from collections import defaultdict
 from itertools import chain
+from unidecode import unidecode
 
 from salmon.common import re_strip
 from salmon.errors import TrackCombineError
@@ -128,10 +129,13 @@ def combine_tracks(base, meta):
                 btrack = next(btracks)
             except StopIteration:
                 raise TrackCombineError(f"Disc {disc} track {num} does not exist.")
-
-            if re_strip(track["title"]) != re_strip(btrack["title"]) and btrack["title"] is not None:
+            # Use unidecode comparison when there are accents in the title
+            if re_strip(unidecode(track["title"])) != re_strip(unidecode(btrack["title"])) and btrack["title"] is not None:
                 continue
             if btrack["title"] is None:
+                btrack["title"] = track["title"]
+            # Scraped title is the same than title when ignoring metadatas, and it contains accents and special characters, prefer that one.
+            if re_strip(track["title"]) != re_strip(unidecode(track["title"])) and re_strip(unidecode(track["title"])) == re_strip(unidecode(btrack["title"])):
                 btrack["title"] = track["title"]
             base_artists = {(re_strip(a[0]), a[1]) for a in btrack["artists"]}
             btrack["artists"] = list(btrack["artists"])

--- a/salmon/tagger/combine.py
+++ b/salmon/tagger/combine.py
@@ -66,6 +66,11 @@ def combine_metadatas(*metadatas, base=None):  # noqa: C901
                 base["label"] = metadata["label"]
                 base["catno"] = metadata["catno"]
 
+            if not base["label"] and metadata["label"]:
+                base["label"] = metadata["label"]
+                if not base["catno"] and metadata["catno"]:
+                    base["catno"] = metadata["catno"]
+
             if metadata["comment"]:
                 if not base["comment"]:
                     base["comment"] = metadata["comment"]

--- a/salmon/tagger/cover.py
+++ b/salmon/tagger/cover.py
@@ -1,5 +1,6 @@
 import os
 import re
+import imghdr
 
 import click
 import requests
@@ -22,9 +23,15 @@ def _download_cover(path, cover_url):
     headers = {'User-Agent': 'smoked-salmon-v1'}
     stream = requests.get(cover_url, stream=True, headers=headers)
     if stream.status_code < 400:
-        with open(os.path.join(path, f"{c}over{ext}"), "wb") as f:
+        cover_path = os.path.join(path, f"{c}over{ext}")
+        with open(cover_path, "wb") as f:
             for chunk in stream.iter_content(chunk_size=5096):
                 if chunk:
                     f.write(chunk)
+
+        img_type = imghdr.what(cover_path)
+        if img_type not in ["jpeg", "png"]:
+            os.remove(cover_path)
+            click.secho(f"\nFailed to download cover image (ERROR downloaded file is not an image [JPEG, PNG])", fg="red")
     else:
         click.secho(f"\nFailed to download cover image (ERROR {stream.status_code})", fg="red")

--- a/salmon/tagger/cover.py
+++ b/salmon/tagger/cover.py
@@ -19,8 +19,12 @@ def download_cover_if_nonexistent(path, cover_url):
 def _download_cover(path, cover_url):
     ext = os.path.splitext(cover_url)[1]
     c = "c" if config.LOWERCASE_COVER else "C"
-    stream = requests.get(cover_url, stream=True)
-    with open(os.path.join(path, f"{c}over{ext}"), "wb") as f:
-        for chunk in stream.iter_content(chunk_size=5096):
-            if chunk:
-                f.write(chunk)
+    headers = {'User-Agent': 'smoked-salmon-v1'}
+    stream = requests.get(cover_url, stream=True, headers=headers)
+    if stream.status_code < 400:
+        with open(os.path.join(path, f"{c}over{ext}"), "wb") as f:
+            for chunk in stream.iter_content(chunk_size=5096):
+                if chunk:
+                    f.write(chunk)
+    else:
+        click.secho(f"\nFailed to download cover image (ERROR {stream.status_code})", fg="red")

--- a/salmon/tagger/metadata.py
+++ b/salmon/tagger/metadata.py
@@ -193,7 +193,13 @@ def clean_metadata(metadata):
                     if i in {"guest", "remixer"}
                 }
                 if re_strip(artist) in guest_artists and importance == "main":
-                    if sum('main' in item for item in metadata["tracks"][disc][num]["artists"]) == 1:
+                    if (
+                        sum(
+                            'main' in item
+                            for item in metadata["tracks"][disc][num]["artists"]
+                        )
+                        == 1
+                    ):
                         pass
                     else:
                         metadata["tracks"][disc][num]["artists"].remove(

--- a/salmon/tagger/pre_data.py
+++ b/salmon/tagger/pre_data.py
@@ -22,6 +22,7 @@ EMPTY_METADATA = {
     "format": None,
     "encoding": None,
     "encoding_vbr": None,
+    "scene": None,
     "source": None,
     "cover": None,
     "upc": None,
@@ -36,6 +37,7 @@ def construct_rls_data(
     audio_info,
     source,
     encoding,
+    scene=False,
     existing=None,
     overwrite=False,
     prompt_encoding=False,
@@ -62,6 +64,7 @@ def construct_rls_data(
         del existing["artists"]
         metadata = {**metadata, **existing}
     metadata["source"] = source
+    metadata["scene"] = scene
     metadata["format"] = parse_format(next(iter(tags.keys())))
 
     audio_track = next(iter(audio_info.values()))

--- a/salmon/tagger/pre_data.py
+++ b/salmon/tagger/pre_data.py
@@ -121,7 +121,7 @@ def create_track_list(tags, overwrite):
     for _, track in sorted(tags.items(), key=lambda k: k):
         trackindex += 1
         discnumber = track.discnumber or "1"
-        tracknumber = track.tracknumber or str(trackindex)
+        tracknumber = track.tracknumber if track.tracknumber and int(track.tracknumber) > 0 else str(trackindex)
         tracks[discnumber][tracknumber] = {
             "track#": tracknumber,
             "disc#": discnumber,
@@ -137,10 +137,10 @@ def create_track_list(tags, overwrite):
             "streamable": None,
         }
         if overwrite:
-            tracks[track.discnumber][track.tracknumber]["artists"] = []
-            tracks[track.discnumber][track.tracknumber]["replay_gain"] = None
-            tracks[track.discnumber][track.tracknumber]["peak"] = None
-            tracks[track.discnumber][track.tracknumber]["isrc"] = None
+            tracks[discnumber][tracknumber]["artists"] = []
+            tracks[discnumber][tracknumber]["replay_gain"] = None
+            tracks[discnumber][tracknumber]["peak"] = None
+            tracks[discnumber][tracknumber]["isrc"] = None
     return dict(tracks)
 
 

--- a/salmon/tagger/retagger.py
+++ b/salmon/tagger/retagger.py
@@ -18,7 +18,7 @@ from salmon.tagger.tagfile import TagFile
 Change = namedtuple("Change", ["tag", "old", "new"])
 
 
-def tag_files(path, tags, metadata):
+def tag_files(path, tags, metadata, auto_rename):
     """
     Wrapper function that calls the functions that create and print the
     proposed changes, and then prompts for confirmation to retag the file.
@@ -29,7 +29,7 @@ def tag_files(path, tags, metadata):
     album_changes = collect_album_data(metadata)
     track_changes = create_track_changes(tags, metadata)
     print_changes(album_changes, track_changes, next(iter(tags.values())))
-    if click.confirm(
+    if auto_rename or click.confirm(
         click.style(
             "\nWould you like to auto-tag the files with the updated metadata?",
             fg="magenta",
@@ -224,7 +224,7 @@ def retag_files(path, album_changes, track_changes):
     click.secho("Retagged files.", fg="green")
 
 
-def rename_files(path, tags, metadata, source=None):
+def rename_files(path, tags, metadata, auto_rename, source=None):
     """
     Call functions that generate the proposed changes, then print and prompt
     for confirmation. Apply the changes if user agrees.
@@ -263,7 +263,7 @@ def rename_files(path, tags, metadata, source=None):
 
     if to_rename:
         print_filenames(to_rename)
-        if click.confirm(
+        if auto_rename or click.confirm(
             click.style(
                 "\nWould you like to rename the files?", fg="magenta", bold=True
             ),

--- a/salmon/tagger/retagger.py
+++ b/salmon/tagger/retagger.py
@@ -282,7 +282,8 @@ def rename_files(path, tags, metadata, auto_rename, source=None):
                     )
                 )
                 new_path, new_path_ext = os.path.splitext(os.path.join(path, new_name))
-                new_path = new_path[: 200 - len(new_path_ext)] + new_path_ext
+               # new_path = new_path[: 200 - len(new_path_ext) + len(os.path.dirname(path))] + new_path_ext
+                new_path = new_path + new_path_ext
                 os.rename(os.path.join(path, filename), new_path)
             move_non_audio_files(directory_move_pairs)
             delete_empty_folders(path)

--- a/salmon/tagger/sources/__init__.py
+++ b/salmon/tagger/sources/__init__.py
@@ -11,14 +11,14 @@ from salmon.tagger.sources import (
     itunes,
     junodownload,
     musicbrainz,
-    tidal,
+#    tidal,
 )
 
 METASOURCES = {
     "MusicBrainz": musicbrainz,
     "iTunes": itunes,
     "Junodownload": junodownload,
-    "Tidal": tidal,
+#    "Tidal": tidal,
     "Deezer": deezer,
     "Discogs": discogs,
     "Beatport": beatport,

--- a/salmon/tagger/sources/bandcamp.py
+++ b/salmon/tagger/sources/bandcamp.py
@@ -51,7 +51,9 @@ class Scraper(BandcampBase, MetadataMixin):
 
     def parse_release_label(self, soup):
         try:
-            artist = soup.select('#name-section span[itemprop="byArtist"] a')[0].string
+            namesection = soup.select('#name-section')
+            for div in namesection:
+                artist = div.find("span").text.strip()
             label = soup.select("#band-name-location .title")[0].string
             if artist != label:
                 return label
@@ -60,18 +62,17 @@ class Scraper(BandcampBase, MetadataMixin):
 
     def parse_tracks(self, soup):
         tracks = defaultdict(dict)
-        artist = soup.select('#name-section span[itemprop="byArtist"] a')[0].string
+        namesection = soup.select('#name-section')
+        for div in namesection:
+            artist = div.find("span").text.strip()
+        various = artist
         tracklist_scrape = soup.select("#track_table tr.track_row_view")
-        various = all(
-            " - " in t.select('.title-col span[itemprop="name"]')[0].string
-            for t in tracklist_scrape
-        )
         for track in tracklist_scrape:
             try:
                 num = track.select(".track-number-col .track_number")[0].text.rstrip(
                     "."
                 )
-                title = track.select('.title-col span[itemprop="name"]')[0].string
+                title = track.select('.title-col span[class="track-title"]')[0].string
                 tracks["1"][num] = self.generate_track(
                     trackno=int(num),
                     discno=1,

--- a/salmon/tagger/sources/base.py
+++ b/salmon/tagger/sources/base.py
@@ -41,6 +41,7 @@ class MetadataMixin(ABC):
             "tracks": self.parse_tracks(soup),
             "upc": self.parse_upc(soup),
             "comment": self.parse_comment(soup),
+            "scene": False,
             "encoding": None,
             "encoding_vbr": None,
             "media": None,
@@ -97,7 +98,7 @@ class MetadataMixin(ABC):
         num_tracks = len(
             list(chain.from_iterable([d.values() for d in data["tracks"].values()]))
         )
-        if re.search(r"E\.?P\.?$", data["title"]):
+        if re.search(r"E\.?P\.?$", data["title"], re.IGNORECASE):
             return (
                 re.sub(r" ?-? *E\.?P\.?$", "", data["title"], flags=re.IGNORECASE),
                 "EP",
@@ -111,8 +112,8 @@ class MetadataMixin(ABC):
             return data["title"], "Soundtrack"
         elif len([a for a in data["artists"] if a[1] == "main"]) > 4:
             return data["title"], "Compilation"
-        elif num_tracks < 3:
-            return data["title"], "Single"
+        #elif num_tracks < 3:
+        #    return data["title"], "Single"
         elif num_tracks < 5:
             return data["title"], "EP"
         return data["title"], data["rls_type"]

--- a/salmon/tagger/sources/discogs.py
+++ b/salmon/tagger/sources/discogs.py
@@ -140,17 +140,18 @@ def parse_artists(artist_soup, track):
             )
         ]
     if "extraartists" in track:
-        artists += [
-            *(
-                (sanitize_artist_name(art["name"]), ROLES[art["role"]])
-                for art in track["extraartists"]
-                if art["role"] in ROLES
-            )
-        ]
-        for a, i in [
-            (a, i) for a, i in artists if i != "main" and (a, "main") in artists
-        ]:
-            artists.remove((a, "main"))
+        for art in track["extraartists"]:
+            for role in art['role'].split(","):
+                role = role.strip()
+                if role in ROLES:
+                    artists.append((sanitize_artist_name(art['name']), ROLES[role]))
+        for name, role in artists:
+            if role != "main" and (name, "main") in artists:
+                artists.remove((name, "main"))
+#        for a, i in [
+#            (a, i) for a, i in artists if i != "main" and (a, "main") in artists
+#        ]:
+#            artists.remove((a, "main"))
     return artists
 
 

--- a/salmon/tagger/tags.py
+++ b/salmon/tagger/tags.py
@@ -47,7 +47,7 @@ def check_required_tags(tags):
         for t in ["title", "artist", "album", "tracknumber"]:
             missing = []
             if not getattr(tags, t, False):
-                missing.add(t)
+                missing.append(t)
             if missing:
                 offending_files.append(f'{fln} ({", ".join(missing)})')
 

--- a/salmon/tagger/tags.py
+++ b/salmon/tagger/tags.py
@@ -91,6 +91,8 @@ def standardize_tags(path):
     """
     for filename in get_audio_files(path):
         mut = mutagen.File(os.path.join(path, filename))
+        if not mut.tags:
+            mut.tags = []
         found_aliased = set()
         for tag, aliases in STANDARDIZED_TAGS.items():
             for alias in aliases:

--- a/salmon/trackers/__init__.py
+++ b/salmon/trackers/__init__.py
@@ -6,7 +6,7 @@ import click
 
 # hard coded as it needs to reflect the imports anyway.
 tracker_classes = {'RED': red.RedApi, 'OPS': ops.OpsApi}
-tracker_url_code_map = {'redacted.ch': 'RED', 'orpheus.network': 'OPS'}
+tracker_url_code_map = {'redacted.sh': 'RED', 'orpheus.network': 'OPS'}
 
 # tracker_list is used to offer the user choices. Generated if not specified in the config.
 if hasattr(config, 'TRACKER_LIST'):

--- a/salmon/trackers/__init__.py
+++ b/salmon/trackers/__init__.py
@@ -1,8 +1,8 @@
-import click
 from urllib import parse
 
 from salmon import ConfigError, config
 from salmon.trackers import red, ops
+import click
 
 # hard coded as it needs to reflect the imports anyway.
 tracker_classes = {'RED': red.RedApi, 'OPS': ops.OpsApi}

--- a/salmon/trackers/base.py
+++ b/salmon/trackers/base.py
@@ -59,6 +59,8 @@ class BaseGazelleApi:
             "Cache-Control": "max-age=0",
             "User-Agent": config.USER_AGENT,
         }
+        if self.api_key:
+            self.headers.update({"Authorization": self.api_key})
         self.dot_torrents_dir = config.DOTTORRENTS_DIR
         self.session = requests.Session()
         self.session.headers.update(self.headers)
@@ -77,8 +79,9 @@ class BaseGazelleApi:
 
     def authenticate(self):
         """Make a request to the site API with the saved cookie and get our authkey."""
-        self.session.cookies.clear()
-        self.session.cookies["session"] = self.cookie
+        if not self.api_key:
+            self.session.cookies.clear()
+            self.session.cookies["session"] = self.cookie
         try:
             acctinfo = loop.run_until_complete(self.request("index"))
         except RequestError:

--- a/salmon/trackers/ops.py
+++ b/salmon/trackers/ops.py
@@ -1,3 +1,5 @@
+import re
+
 from salmon.trackers.base import BaseGazelleApi
 
 from salmon import config
@@ -5,14 +7,11 @@ import click
 import requests
 from requests.exceptions import ConnectTimeout, ReadTimeout
 
+from bs4 import BeautifulSoup
+
 
 class OpsApi(BaseGazelleApi):
     def __init__(self):
-        self.headers = {
-            "Connection": "keep-alive",
-            "Cache-Control": "max-age=0",
-            "User-Agent": config.USER_AGENT,
-        }
         self.site_code = 'OPS'
         self.base_url = 'https://orpheus.network'
         self.tracker_url = 'https://home.opsfet.ch'
@@ -23,10 +22,20 @@ class OpsApi(BaseGazelleApi):
             self.dot_torrents_dir = config.DOTTORRENTS_DIR
 
         self.cookie = config.OPS_SESSION
+        if config.OPS_API_KEY:
+            self.api_key = config.OPS_API_KEY
 
-        self.session = requests.Session()
-        self.session.headers.update(self.headers)
+        super().__init__()
 
-        self.authkey = None
-        self.passkey = None
-        self.authenticate()
+    def parse_most_recent_torrent_and_group_id_from_group_page(self, text):
+        """
+        Given the HTML (ew) response from a successful upload, find the most
+        recently uploaded torrent (it better be ours).
+        """
+        torrent_ids = []
+        soup = BeautifulSoup(text, "html.parser")
+        for pl in soup.find_all("a", class_="tooltip"):
+            torrent_url = re.search(r"torrents.php\?id=(\d+)", pl["href"])
+            if torrent_url:
+                torrent_ids.append(int(torrent_url[1]))
+        return max(torrent_ids)

--- a/salmon/trackers/red.py
+++ b/salmon/trackers/red.py
@@ -18,7 +18,7 @@ loop = asyncio.get_event_loop()
 class RedApi(BaseGazelleApi):
     def __init__(self):
         self.site_code = 'RED'
-        self.base_url = 'https://redacted.ch'
+        self.base_url = 'https://redacted.sh'
         self.tracker_url = 'https://flacsfor.me'
         self.site_string = 'RED'
         self.cookie = config.RED_SESSION

--- a/salmon/trackers/red.py
+++ b/salmon/trackers/red.py
@@ -17,11 +17,6 @@ loop = asyncio.get_event_loop()
 
 class RedApi(BaseGazelleApi):
     def __init__(self):
-        self.headers = {
-            "Connection": "keep-alive",
-            "Cache-Control": "max-age=0",
-            "User-Agent": config.USER_AGENT,
-        }
         self.site_code = 'RED'
         self.base_url = 'https://redacted.ch'
         self.tracker_url = 'https://flacsfor.me'
@@ -35,16 +30,11 @@ class RedApi(BaseGazelleApi):
         else:
             self.dot_torrents_dir = config.DOTTORRENTS_DIR
 
-        self.session = requests.Session()
-        self.session.headers.update(self.headers)
-
-        self.authkey = None
-        self.passkey = None
-        self.authenticate()
+        super().__init__()
 
     async def report_lossy_master(self, torrent_id, comment, source):
         """Automagically report a torrent for lossy master/web approval.
-         Use LWA if the torrent is web, otherwise LMA."""
+        Use LWA if the torrent is web, otherwise LMA."""
 
         url = self.base_url + "/reportsv2.php"
         params = {"action": "takereport"}

--- a/salmon/uploader/__init__.py
+++ b/salmon/uploader/__init__.py
@@ -262,7 +262,8 @@ def upload(
             searchstrs = generate_dupe_check_searchstrs(
                 rls_data["artists"], rls_data["title"], rls_data["catno"]
             )
-            group_id = check_existing_group(gazelle_site, searchstrs)
+            if len(searchstrs) > 0:
+                group_id = check_existing_group(gazelle_site, searchstrs)
 
         if spectrals_after:
             lossy_master = False

--- a/salmon/uploader/__init__.py
+++ b/salmon/uploader/__init__.py
@@ -51,7 +51,11 @@ from salmon.uploader.upload import (
     concat_track_data,
     prepare_and_upload,
 )
+from salmon.rutorrent.rutorrent import (
+    add_torrent_to_rutorrent
+)
 from salmon.checks.upconverts import upload_upconvert_test
+from salmon.checks.integrity import (check_integrity, sanitize_integrity)
 
 loop = asyncio.get_event_loop()
 
@@ -114,6 +118,36 @@ loop = asyncio.get_event_loop()
     is_flag=True,
     help='Assess / upload / report spectrals after torrent upload',
 )
+@click.option(
+    "--auto-rename",
+    "-n",
+    is_flag=True,
+    help=f'Rename files and folders automatically',
+)
+@click.option(
+    "--skip-up",
+    is_flag=True,
+    help=f'Skip check for 24 bit upconversion',
+)
+@click.option(
+    "--scene",
+    is_flag=True,
+    help=f'Is this a scene release (default: False)'
+)
+@click.option(
+    "--rutorrent",
+    is_flag=True,
+    help=f'Adds torrent to Rutorrent tracker after torrent upload (default: False)'
+)
+@click.option("--source-url", "-su", 
+    default=None, 
+    help=f'For WEB uploads provide the source of the album to be added in release description'
+)
+@click.option(
+    "-yyy",
+    is_flag=True,
+    help=f'Automatically pick the default answer for prompt'
+)
 def up(
     path,
     group_id,
@@ -126,8 +160,16 @@ def up(
     tracker,
     request,
     spectrals_after,
+    auto_rename,
+    skip_up,
+    scene,
+    rutorrent,
+    source_url,
+    yyy
 ):
     """Command to upload an album folder to a Gazelle Site."""
+    if yyy:
+        config.YES_ALL = True
     gazelle_site = salmon.trackers.get_class(tracker)()
     if request:
         request = salmon.trackers.validate_request(gazelle_site, request)
@@ -142,6 +184,8 @@ def up(
         encoding,
         spectrals_after,
     )
+    if source_url:
+        source_url = source_url.strip()
     upload(
         gazelle_site,
         path,
@@ -150,10 +194,15 @@ def up(
         lossy,
         spectrals,
         encoding,
+        source_url=source_url,
+        scene=scene,
+        rutorrent=rutorrent,
         overwrite_meta=overwrite,
         recompress=compress,
         request_id=request,
         spectrals_after=spectrals_after,
+        auto_rename=auto_rename,
+        skip_up=skip_up,
     )
 
 
@@ -165,6 +214,8 @@ def upload(
     lossy,
     spectrals,
     encoding,
+    scene=False,
+    rutorrent=False,
     existing=None,
     overwrite_meta=False,
     recompress=False,
@@ -172,6 +223,8 @@ def upload(
     searchstrs=None,
     request_id=None,
     spectrals_after=False,
+    auto_rename=False,
+    skip_up=False,
 ):
     """Upload an album folder to Gazelle Site
     Offer the choice to upload to another tracker after completion."""
@@ -187,20 +240,23 @@ def upload(
         audio_info,
         source,
         encoding,
+        scene=scene,
         existing=existing,
         overwrite=overwrite_meta,
         prompt_encoding=True,
     )
 
     try:
-        if rls_data["encoding"] == "24bit Lossless" and click.confirm(
-            click.style(
-                "24bit detected. Do you want to check whether might be upconverted?",
-                fg="magenta",
-            ),
-            default=True,
-        ):
-            upload_upconvert_test(path)
+        if rls_data["encoding"] == "24bit Lossless" and not skip_up:
+            if not config.YES_ALL:
+                if click.confirm(
+                        click.style(
+                            "24bit detected. Do you want to check whether might be upconverted?",
+                            fg="magenta",),
+                        default=True,):
+                    upload_upconvert_test(path)
+            else:
+                upload_upconvert_test(path)
 
         if group_id is None:
             searchstrs = generate_dupe_check_searchstrs(
@@ -218,7 +274,7 @@ def upload(
         metadata = get_metadata(path, tags, rls_data)
         download_cover_if_nonexistent(path, metadata["cover"])
         path, metadata, tags, audio_info = edit_metadata(
-            path, tags, metadata, source, rls_data, recompress
+            path, tags, metadata, source, rls_data, recompress, auto_rename
         )
         if not group_id:
             group_id = recheck_dupe(gazelle_site, searchstrs, metadata)
@@ -249,7 +305,7 @@ def upload(
 
     if not group_id:
         # This prevents the cover being uploaded more than once for multiple sites.
-        cover_url = upload_cover(path)
+        cover_url = upload_cover(path, scene)
     else:
         cover_url = None
 
@@ -283,7 +339,7 @@ def upload(
         if not request_id and config.CHECK_REQUESTS:
             request_id = check_requests(gazelle_site, searchstrs)
 
-        torrent_id = prepare_and_upload(
+        torrent_id, torrent_path, torrent_file = prepare_and_upload(
             gazelle_site,
             path,
             group_id,
@@ -295,6 +351,7 @@ def upload(
             spectral_urls,
             lossy_comment,
             request_id,
+            source_url
         )
         if lossy_master:
             report_lossy_master(
@@ -313,6 +370,13 @@ def upload(
             fg="green",
             bold=True,
         )
+        if rutorrent:
+            click.secho(
+            f"\nAdding torrent to client {config.RUTORRENT_URL} {config.TRACKER_DIRS[tracker]} {config.TRACKER_LABELS[tracker]}",
+            fg="green",
+            bold=True
+            )
+            add_torrent_to_rutorrent(config.RUTORRENT_URL, torrent_path, config.TRACKER_DIRS[tracker], config.TRACKER_LABELS[tracker])
         if config.COPY_UPLOADED_URL_TO_CLIPBOARD:
             pyperclip.copy(url)
         tracker = None
@@ -321,7 +385,7 @@ def upload(
             return click.secho("\nDone uploading this release.", fg="green")
 
 
-def edit_metadata(path, tags, metadata, source, rls_data, recompress):
+def edit_metadata(path, tags, metadata, source, rls_data, recompress, auto_rename):
     """
     The metadata editing portion of the uploading process. This sticks the user
     into an infinite loop where the metadata process is repeated until the user
@@ -329,16 +393,33 @@ def edit_metadata(path, tags, metadata, source, rls_data, recompress):
     """
     while True:
         metadata = review_metadata(metadata, metadata_validator)
-        tag_files(path, tags, metadata)
+        if not metadata['scene']:
+            tag_files(path, tags, metadata, auto_rename)
 
         tags = check_tags(path)
         if recompress:
             recompress_path(path)
-        path = rename_folder(path, metadata)
-        rename_files(path, tags, metadata, source)
-        check_folder_structure(path)
+        path = rename_folder(path, metadata, auto_rename)
+        if not metadata['scene']:
+            rename_files(path, tags, metadata, auto_rename, source)
+            check_folder_structure(path)
 
-        if click.confirm(
+        if config.YES_ALL or click.confirm(
+            click.style(
+                "Do you want to check for integrity of this upload?",
+                fg="magenta"),
+            default=True,
+            ):
+            (integrity, integrity_output) = check_integrity(path)
+            if not integrity and True if config.YES_ALL else click.confirm(
+                click.style(
+                    "Do you want to sanitize this upload?",
+                    fg="magenta"),
+                default=True,
+                ):
+                sanitize_integrity(path)
+
+        if config.YES_ALL or click.confirm(
             click.style(
                 "\nWould you like to upload the torrent? (No to re-run metadata "
                 "section)",

--- a/salmon/uploader/dupe_checker.py
+++ b/salmon/uploader/dupe_checker.py
@@ -1,15 +1,13 @@
 import asyncio
 import re
-from urllib import parse
 from difflib import SequenceMatcher as SM
+from urllib import parse
 
 import click
 
-
-from salmon.common import RE_FEAT, make_searchstrs
-from salmon.errors import AbortAndDeleteFolder
-from salmon.errors import RequestError
 from salmon import config
+from salmon.common import RE_FEAT, make_searchstrs
+from salmon.errors import AbortAndDeleteFolder, RequestError
 
 loop = asyncio.get_event_loop()
 

--- a/salmon/uploader/preassumptions.py
+++ b/salmon/uploader/preassumptions.py
@@ -4,9 +4,7 @@ from html import unescape
 import click
 
 from salmon import config
-from salmon.errors import UploadError
-
-from salmon.errors import RequestError
+from salmon.errors import RequestError, UploadError
 
 loop = asyncio.get_event_loop()
 

--- a/salmon/uploader/request_checker.py
+++ b/salmon/uploader/request_checker.py
@@ -3,13 +3,11 @@ import re
 from urllib import parse
 
 import click
+import rich
 
 from salmon import config
-from salmon.common import RE_FEAT, make_searchstrs, format_size
-from salmon.errors import AbortAndDeleteFolder
-
-from salmon.errors import RequestError
-import rich
+from salmon.common import RE_FEAT, format_size, make_searchstrs
+from salmon.errors import AbortAndDeleteFolder, RequestError
 
 loop = asyncio.get_event_loop()
 
@@ -107,7 +105,8 @@ def _print_request_details(gazelle_site, req):
         req['mediaList'].append(str('CD ' + req['logCue']))
     click.secho(f"Allowed   Media: {' | '.join(req['mediaList'])}")
     click.secho(
-        'Description:', fg="cyan",
+        'Description:',
+        fg="cyan",
     )
     description = req['bbDescription'].splitlines(True)
 

--- a/salmon/uploader/spectrals.py
+++ b/salmon/uploader/spectrals.py
@@ -347,7 +347,7 @@ def prompt_spectrals(spectral_ids, lossy_master, check_lma):
         ids = "*" if config.YES_ALL else click.prompt(
             click.style(
                 f"What spectral IDs would you like to upload to "
-                f"{config.SPECS_UPLOADER}? (\" * \" for all)",
+                f"{config.SPECS_UPLOADER}? (\" * \" for all, \"0\" for none)",
                 fg="magenta",
                 bold=True,
             ),
@@ -355,6 +355,8 @@ def prompt_spectrals(spectral_ids, lossy_master, check_lma):
         )
         if ids.strip() == "*":
             return spectral_ids
+        elif is.strip() == "0":
+            return None
         ids = [i.strip() for i in ids.split()]
         if not ids and lossy_master and check_lma:
             click.secho(

--- a/salmon/uploader/spectrals.py
+++ b/salmon/uploader/spectrals.py
@@ -355,7 +355,7 @@ def prompt_spectrals(spectral_ids, lossy_master, check_lma):
         )
         if ids.strip() == "*":
             return spectral_ids
-        elif is.strip() == "0":
+        elif ids.strip() == "0":
             return None
         ids = [i.strip() for i in ids.split()]
         if not ids and lossy_master and check_lma:

--- a/salmon/web/__init__.py
+++ b/salmon/web/__init__.py
@@ -19,7 +19,7 @@ loop = asyncio.get_event_loop()
 def web():
     """Start the salmon web server"""
     app = create_app()  # noqa: F841
-    click.secho(f"Running webserver on http://127.0.0.1:{config.WEB_PORT}", fg="cyan")
+    click.secho(f"Running webserver on http://{config.WEB_HOST}:{config.WEB_PORT}", fg="cyan")
     loop.run_forever()
 
 
@@ -30,7 +30,7 @@ def create_app():
         app, loader=jinja2.FileSystemLoader(join(dirname(__file__), "templates"))
     )
     return loop.run_until_complete(
-        loop.create_server(app.make_handler(), host="127.0.0.1", port=config.WEB_PORT)
+        loop.create_server(app.make_handler(), host=config.WEB_HOST, port=config.WEB_PORT)
     )
 
 
@@ -42,7 +42,7 @@ async def create_app_async():
     )
     runner = aiohttp.web.AppRunner(app)
     await runner.setup()
-    site = aiohttp.web.TCPSite(runner, "127.0.0.1", config.WEB_PORT)
+    site = aiohttp.web.TCPSite(runner, config.WEB_HOST, config.WEB_PORT)
     try:
         await site.start()
     except OSError:

--- a/salmon/web/spectrals.py
+++ b/salmon/web/spectrals.py
@@ -11,7 +11,6 @@ from salmon.database import DB_PATH
 
 async def handle_spectrals(request, **kwargs):
     active_spectrals = get_active_spectrals()
-    print(active_spectrals)
     if active_spectrals:
         active_spectrals['now'] = datetime.datetime.now()
         return render_template("spectrals.html", request, active_spectrals)

--- a/salmon/web/spectrals.py
+++ b/salmon/web/spectrals.py
@@ -4,12 +4,16 @@ from itertools import chain
 import aiohttp
 from aiohttp_jinja2 import render_template
 
+import datetime
+
 from salmon.database import DB_PATH
 
 
 async def handle_spectrals(request, **kwargs):
     active_spectrals = get_active_spectrals()
+    print(active_spectrals)
     if active_spectrals:
+        active_spectrals['now'] = datetime.datetime.now()
         return render_template("spectrals.html", request, active_spectrals)
     return aiohttp.web.HTTPNrtFound()
 

--- a/salmon/web/templates/spectrals.html
+++ b/salmon/web/templates/spectrals.html
@@ -13,12 +13,12 @@
     <p><span class="filename_spectral">{{ filename }}</span></p>
     <div class="track_spectrals">
         <div class="full_spectral_image">
-            <img src="{{ static('/specs') }}/{{ '%02d' | format(id) }} Full.png"
+            <img src="{{ static('/specs') }}/{{ '%02d' | format(id) }} Full.png?{{ now }}"
                  alt="Full spectral for {{ filename }}"
                  onclick="show_lightbox({{ id }});">
         </div>
         <div class="zoom_spectral_image">
-            <img src="{{ static('/specs') }}/{{ '%02d' | format(id) }} Zoom.png"
+            <img src="{{ static('/specs') }}/{{ '%02d' | format(id) }} Zoom.png?{{ now }}"
                  alt="Zoom spectral for {{ filename }}"
                  onclick="show_lightbox({{ id }});">
         </div>


### PR DESCRIPTION
https://codeberg.org/xmoforf/smoked-salmon/commits/branch/xmoforf

To name a few of the features brought in this meta commit:

- Compatibility with OPS
- Support for scene uploads
- Support for more automation with options to skip things or do defaults
- Support for auto seed (ruTorrent only)
- Better merge of the label metadata from scrappers
- Sanitizes uploads before creating torrent (good for WEB uploads with unset MD5s)
- Copies source, instead of moving. Good in case of errors, the original source is untouched

Following there is a list of descriptions of the commits:

    bugfix: beatport has stopped using their 'pro' subdomain, using just beatport.com instead to fix bug where salmon was unable to fetch metadata from beatport

    Fixed OPS group parsing

    bandcamp scraper quick fix

    Ensured attribution to project originator and other major contributors.

    disable broken tidal tagger. needs authentication currently returns 401.

    added .venv and .python-version to .gitignore

    Updated for 3.9 or 3.10

    A bunch of pip version bumping.

    black

    add rip log fetch

    Inheritance fix.

    Some options to speed up workflow
    1. --auto-rename (skips confirmation of folder and file renaming)
    2. --skip-up (skips 24-bit upconversion check)

    OPS support

    - support for OPS api key
    - fixed issue with OPS response torrentId field

    writes .torrent to torrent folder instead of moving from tmp

    support for scene uploads

    support for weird cover names with scene

    fixed non-scene uploads

    automating a few things with scene release

    auto seed with remote rutorrent

    adding integrity checks and fixes in upload process

    support for source url

    yes to "all" option

    Yes to all feature and iTunes release parser improvements

    fix yes to all + deezer set label

    removing and fixing some printed messages