### PR TITLE
Disable follow_symlinks

### DIFF
--- a/salmon/web/__init__.py
+++ b/salmon/web/__init__.py
@@ -51,9 +51,7 @@ async def create_app_async():
 
 
 def add_routes(app):
-    app.router.add_static(
-        "/static", join(dirname(__file__), "static"), follow_symlinks=True
-    )
+    app.router.add_static("/static", join(dirname(__file__), "static"))
     app.router.add_route("GET", "/", handle_index)
     app.router.add_route("GET", "/spectrals", spectrals.handle_spectrals)
     app["static_root_url"] = config.WEB_STATIC_ROOT_URL


### PR DESCRIPTION
I'm checking that this parameter wasn't set by mistake.
The parameter allows a symlink to point to somewhere _outside_ of the static directory. Symlinks that point within the directory will work without enabling this parameter (it's badly named). Therefore enabling this option could make it easy to misconfigure an environment and introduce security issues.